### PR TITLE
Update to use OT java api 0.31.0-RC1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Eclipse
+.project
+.classpath
+.settings
+

--- a/opentracing-vertx-web/src/main/java/io/opentracing/contrib/vertx/ext/web/WebSpanDecorator.java
+++ b/opentracing-vertx-web/src/main/java/io/opentracing/contrib/vertx/ext/web/WebSpanDecorator.java
@@ -4,7 +4,7 @@ import io.vertx.core.Handler;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.opentracing.BaseSpan;
+import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -21,7 +21,7 @@ public interface WebSpanDecorator {
      * @param request server request
      * @param span server span
      */
-    void onRequest(HttpServerRequest request, BaseSpan<?> span);
+    void onRequest(HttpServerRequest request, Span span);
 
     /**
      * Decorate span when span is rerouted.
@@ -29,7 +29,7 @@ public interface WebSpanDecorator {
      * @param request server request
      * @param span server span
      */
-    void onReroute(HttpServerRequest request, BaseSpan<?> span);
+    void onReroute(HttpServerRequest request, Span span);
 
     /**
      * Decorate span when the response is known. This is effectively invoked in BodyEndHandler which is added to
@@ -38,7 +38,7 @@ public interface WebSpanDecorator {
      * @param request server request
      * @param span server span
      */
-    void onResponse(HttpServerRequest request, BaseSpan<?> span);
+    void onResponse(HttpServerRequest request, Span span);
 
     /**
      * Decorate request when an exception is thrown during request processing.
@@ -47,21 +47,21 @@ public interface WebSpanDecorator {
      * @param response server response
      * @param span server span
      */
-    void onFailure(Throwable throwable, HttpServerResponse response, BaseSpan<?> span);
+    void onFailure(Throwable throwable, HttpServerResponse response, Span span);
 
     /**
      * Decorator which adds standard set of tags e.g. HTTP/PEER/ERROR tags.
      */
     class StandardTags implements WebSpanDecorator {
         @Override
-        public void onRequest(HttpServerRequest request, BaseSpan<?> span) {
+        public void onRequest(HttpServerRequest request, Span span) {
             Tags.COMPONENT.set(span, "vertx");
             Tags.HTTP_METHOD.set(span, request.method().toString());
             Tags.HTTP_URL.set(span, request.absoluteURI());
         }
 
         @Override
-        public void onReroute(HttpServerRequest request, BaseSpan<?> span) {
+        public void onReroute(HttpServerRequest request, Span span) {
             Map<String, String> logs = new HashMap<>(2);
             logs.put("event", "reroute");
             logs.put(Tags.HTTP_URL.getKey(), request.absoluteURI());
@@ -70,12 +70,12 @@ public interface WebSpanDecorator {
         }
 
         @Override
-        public void onResponse(HttpServerRequest request, BaseSpan<?> span) {
+        public void onResponse(HttpServerRequest request, Span span) {
             Tags.HTTP_STATUS.set(span, request.response().getStatusCode());
         }
 
         @Override
-        public void onFailure(Throwable throwable, HttpServerResponse response, BaseSpan<?> span) {
+        public void onFailure(Throwable throwable, HttpServerResponse response, Span span) {
             Tags.ERROR.set(span, Boolean.TRUE);
 
             if (throwable != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.opentracing>0.30.0</version.io.opentracing>
+    <version.io.opentracing>0.31.0-RC1</version.io.opentracing>
     <version.io.vertx>3.4.2</version.io.vertx>
     <version.junit>4.12</version.junit>
     <version.com.jayway.awaitility-awaitility>3.0.0</version.com.jayway.awaitility-awaitility>


### PR DESCRIPTION
This PR highlights the changes that will be required when moving to the new OT Java API - currently available as a release candidate.

Note sure worth releasing, as only minor changes required? Does not really provide any useful additional test cases for the RC itself.

If would like to still release against RC1, then I'll create the branch, update publish script etc.