### PR TITLE
Exposed finishEndHandler to subclasses

### DIFF
--- a/opentracing-vertx-web/src/main/java/io/opentracing/contrib/vertx/ext/web/TracingHandler.java
+++ b/opentracing-vertx-web/src/main/java/io/opentracing/contrib/vertx/ext/web/TracingHandler.java
@@ -91,7 +91,7 @@ public class TracingHandler implements Handler<RoutingContext> {
         routingContext.next();
     }
 
-    private Handler<Void> finishEndHandler(RoutingContext routingContext, Span span) {
+    protected final Handler<Void> finishEndHandler(RoutingContext routingContext, Span span) {
         return handler -> {
             decorators.forEach(spanDecorator ->
                     spanDecorator.onResponse(routingContext.request(), span));


### PR DESCRIPTION
Why? 
This allows us to override `handlerNormal(...)` without copy/pasting `finishEndHandler(...)`