### PR TITLE
Use the correct class name in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ router.route()
 Because Vert.x is event loop based, thread local implementations of span source do not work.
 The current solution is to get span context from `RoutingContext` and then pass it manually around.
 ```java
-SpanContext serverContext = TracingFilter.serverSpanContext(routingContext);
+SpanContext serverContext = TracingHandler.serverSpanContext(routingContext);
 ```
 
 ## Development


### PR DESCRIPTION
Example in the Readme uses a non-existing class name: `TracingFilter` and it's causing some [confusion](https://github.com/opentracing-contrib/java-vertx-web/issues/18). The correct name is `TracingHandler`. 